### PR TITLE
Reworked param messaging

### DIFF
--- a/.templates/aws/networks.yml
+++ b/.templates/aws/networks.yml
@@ -3,37 +3,35 @@ networks:
 - name: sawmill_z1
   type: manual
   subnets: 
-  - range: (( param "Enter the CIDR address for this subnet (networks.0<sawmill_z1>.subnets.range)" ))
-    gateway: (( param "Enter the Gateway for this subnet (networks.0<sawmill_z1>.subnets.gateway)" ))
+  - range: (( param "Enter the CIDR address for this subnet" ))
+    gateway: (( param "Enter the Gateway for this subnet" ))
     dns: (( grab meta.dns ))
-    static: (( param "Enter the static IP ranges for this subnet (networks.0<sawmill_z1>.subnets.static)" ))
-    reserved: (( param "Enter the reserved IP ranges for this subnet (networks.0<sawmill_z1>.subnets.reserved)" ))
+    static: (( param "Enter the static IP ranges for this subnet" ))
+    reserved: (( param "Enter the reserved IP ranges for this subnet" ))
     cloud_properties:
       security_groups: (( grab meta.security_groups ))
-      subnet: (( param "Enter the AWS subnet ID for this subnet (networks.0<sawmill_z1>.subnets.cloud_properties.subnet))" ))
+      subnet: (( param "Enter the AWS subnet ID for this subnet" ))
 
 - name: sawmill_z2
   type: manual
   subnets: 
-  - range: (( param "Enter the CIDR address for this subnet (networks.0<sawmill_z1>.subnets.range)" ))
-    gateway: (( param "Enter the Gateway for this subnet (networks.0<sawmill_z1>.subnets.gateway)" ))
+  - range: (( param "Enter the CIDR address for this subnet" ))
+    gateway: (( param "Enter the Gateway for this subnet" ))
     dns: (( grab meta.dns ))
-    static: (( param "Enter the static IP ranges for this subnet (networks.0<sawmill_z1>.subnets.static)" ))
-    reserved: (( param "Enter the reserved IP ranges for this subnet (networks.0<sawmill_z1>.subnets.reserved)" ))
+    static: (( param "Enter the static IP ranges for this subnet" ))
+    reserved: (( param "Enter the reserved IP ranges for this subnet" ))
     cloud_properties:
       security_groups: (( grab meta.security_groups ))
-      subnet: (( param "Enter the AWS subnet ID for this subnet (networks.0<sawmill_z1>.subnets.cloud_properties.subnet))" ))
+      subnet: (( param "Enter the AWS subnet ID for this subnet" ))
 
 - name: sawmill_z3
   type: manual
   subnets: 
-  - range: (( param "Enter the CIDR address for this subnet (networks.0<sawmill_z1>.subnets.range)" ))
-    gateway: (( param "Enter the Gateway for this subnet (networks.0<sawmill_z1>.subnets.gateway)" ))
+  - range: (( param "Enter the CIDR address for this subnet" ))
+    gateway: (( param "Enter the Gateway for this subnet" ))
     dns: (( grab meta.dns ))
-    static: (( param "Enter the static IP ranges for this subnet (networks.0<sawmill_z1>.subnets.static)" ))
-    reserved: (( param "Enter the reserved IP ranges for this subnet (networks.0<sawmill_z1>.subnets.reserved)" ))
+    static: (( param "Enter the static IP ranges for this subnet" ))
+    reserved: (( param "Enter the reserved IP ranges for this subnet" ))
     cloud_properties:
       security_groups: (( grab meta.security_groups ))
-      subnet: (( param "Enter the AWS subnet ID for this subnet (networks.0<sawmill_z1>.subnets.cloud_properties.subnet))" ))
-
-
+      subnet: (( param "Enter the AWS subnet ID for this subnet" ))

--- a/.templates/aws/resource-pools.yml
+++ b/.templates/aws/resource-pools.yml
@@ -2,9 +2,9 @@
 meta:
   aws:
     azs:
-      z1: (( param "Define the z1 AWS availability zone (meta.aws.azs.z1)" ))
-      z2: (( param "Define the z2 AWS availability zone (meta.aws.azs.z2)" ))
-      z3: (( param "Define the z3 AWS availability zone (meta.aws.azs.z3)" ))
+      z1: (( param "Define the z1 AWS availability zone" ))
+      z2: (( param "Define the z2 AWS availability zone" ))
+      z3: (( param "Define the z3 AWS availability zone" ))
 
 resource_pools:
   - name: small_z1

--- a/.templates/vsphere/networks.yml
+++ b/.templates/vsphere/networks.yml
@@ -3,38 +3,38 @@ networks:
 - name: sawmill_z1
   type: manual
   subnets: 
-  - range: (( param "Enter the CIDR address for this subnet (networks.0<sawmill_z1>.subnets.range)" ))
-    gateway: (( param "Enter the Gateway for this subnet (networks.0<sawmill_z1>.subnets.gateway)" ))
+  - range: (( param "Enter the CIDR address for this subnet" ))
+    gateway: (( param "Enter the Gateway for this subnet" ))
     dns: (( grab meta.dns ))
-    static: (( param "Enter the static IP ranges for this subnet (networks.0<sawmill_z1>.subnets.static)" ))
-    reserved: (( param "Enter the reserved IP ranges for this subnet (networks.0<sawmill_z1>.subnets.reserved)" ))
+    static: (( param "Enter the static IP ranges for this subnet" ))
+    reserved: (( param "Enter the reserved IP ranges for this subnet" ))
     cloud_properties:
       security_groups: (( grab meta.security_groups ))
-      subnet: (( param "Enter the AWS subnet ID for this subnet (networks.0<sawmill_z1>.subnets.cloud_properties.subnet))" ))
+      subnet: (( param "Enter the AWS subnet ID for this subnet" ))
 
 - name: sawmill_z2
   type: manual
   subnets: 
-  - range: (( param "Enter the CIDR address for this subnet (networks.0<sawmill_z1>.subnets.range)" ))
-    gateway: (( param "Enter the Gateway for this subnet (networks.0<sawmill_z1>.subnets.gateway)" ))
+  - range: (( param "Enter the CIDR address for this subnet" ))
+    gateway: (( param "Enter the Gateway for this subnet" ))
     dns: (( grab meta.dns ))
-    static: (( param "Enter the static IP ranges for this subnet (networks.0<sawmill_z1>.subnets.static)" ))
-    reserved: (( param "Enter the reserved IP ranges for this subnet (networks.0<sawmill_z1>.subnets.reserved)" ))
+    static: (( param "Enter the static IP ranges for this subnet" ))
+    reserved: (( param "Enter the reserved IP ranges for this subnet" ))
     cloud_properties:
       security_groups: (( grab meta.security_groups ))
-      subnet: (( param "Enter the AWS subnet ID for this subnet (networks.0<sawmill_z1>.subnets.cloud_properties.subnet))" ))
+      subnet: (( param "Enter the AWS subnet ID for this subnet" ))
 
 - name: sawmill_z3
   type: manual
   subnets: 
-  - range: (( param "Enter the CIDR address for this subnet (networks.0<sawmill_z1>.subnets.range)" ))
-    gateway: (( param "Enter the Gateway for this subnet (networks.0<sawmill_z1>.subnets.gateway)" ))
+  - range: (( param "Enter the CIDR address for this subnet" ))
+    gateway: (( param "Enter the Gateway for this subnet" ))
     dns: (( grab meta.dns ))
-    static: (( param "Enter the static IP ranges for this subnet (networks.0<sawmill_z1>.subnets.static)" ))
-    reserved: (( param "Enter the reserved IP ranges for this subnet (networks.0<sawmill_z1>.subnets.reserved)" ))
+    static: (( param "Enter the static IP ranges for this subnet" ))
+    reserved: (( param "Enter the reserved IP ranges for this subnet" ))
     cloud_properties:
       security_groups: (( grab meta.security_groups ))
-      subnet: (( param "Enter the AWS subnet ID for this subnet (networks.0<sawmill_z1>.subnets.cloud_properties.subnet))" ))
+      subnet: (( param "Enter the AWS subnet ID for this subnet" ))
 
 
 

--- a/.templates/vsphere/resource-pools.yml
+++ b/.templates/vsphere/resource-pools.yml
@@ -2,9 +2,9 @@
 meta:
   vcenter:
     clusters:
-      z1: (( param "Define the cluster/resource pool config for z1 (meta.vcenter.clusters.z1 )" ))
-      z2: (( param "Define the cluster/resource pool config for z2 (meta.vcenter.clusters.z2 )" ))
-      z3: (( param "Define the cluster/resource pool config for z3 (meta.vcenter.clusters.z3 )" ))
+      z1: (( param "Define the cluster/resource pool config for z1" ))
+      z2: (( param "Define the cluster/resource pool config for z2" ))
+      z3: (( param "Define the cluster/resource pool config for z3" ))
 
 resource_pools:
   - name: small_z1

--- a/global/deployment.yml
+++ b/global/deployment.yml
@@ -1,7 +1,7 @@
 ---
-name: (( param "Please define the deployment name in the environment templates (name)" ))
+name: (( param "Please define the deployment name in the environment templates" ))
 
-director_uuid: (( param "Please provide the UUID of your target BOSH director in the site/environment templates (director_uuid)" ))
+director_uuid: (( param "Please provide the UUID of your target BOSH director in the site/environment templates" ))
 
 update:
   canaries: 1

--- a/global/jobs.yml
+++ b/global/jobs.yml
@@ -1,6 +1,6 @@
 ---
 meta:
-  sawmill_servers: (( param "Please override with the IPs of all the Sawmill servers (meta.sawmill_servers)" ))
+  sawmill_servers: (( param "Please override with the IPs of all the Sawmill servers" ))
 
 jobs:
   sawmill:

--- a/global/properties.yml
+++ b/global/properties.yml
@@ -3,7 +3,8 @@ properties:
 
   sawmill:
 
-    skip_ssl_verify: (( param "Specify whether or not to skip SSL verification (properties.sawmill.skip_ssl_verify)" ))
+    skip_ssl_verify: (( param "Specify whether or not to skip SSL verification" ))
 
-    users: (( param "Specify admin user name & password (properties.sawmill.users.0.{name,pass})" ))
-
+    users: (( param "Specify a list of users to restrict the sawmill HTTP endpoint with" ))
+    #- name: admin
+    #  pass: password


### PR DESCRIPTION
Spruce includes the property path by default when throwing param errors, so I cleaned up the text to be less redundant. Users will now see things like this:

```
$ spruce merge global/properties.yml
2 error(s) detected:
 - $.properties.sawmill.skip_ssl_verify: Specify whether or not to skip SSL verification
 - $.properties.sawmill.users: Specify a list of users to restrict the sawmill HTTP endpoint with
```
