### PR TITLE
Updates

### DIFF
--- a/.templates/aws/networks.yml
+++ b/.templates/aws/networks.yml
@@ -35,5 +35,3 @@ networks:
     cloud_properties:
       security_groups: (( grab meta.security_groups ))
       subnet: (( param "Enter the AWS subnet ID for this subnet (networks.0<sawmill_z1>.subnets.cloud_properties.subnet))" ))
-
-

--- a/.templates/aws/releases
+++ b/.templates/aws/releases
@@ -1,1 +1,2 @@
 sawmill
+toolbelt

--- a/.templates/aws/update.yml
+++ b/.templates/aws/update.yml
@@ -2,5 +2,3 @@
 update:
   canary_watch_time: 1000-60000
   update_watch_time: 1000-60000
-  max_in_flight: 1
-  serial: true

--- a/.templates/bosh-lite/jobs.yml
+++ b/.templates/bosh-lite/jobs.yml
@@ -1,5 +1,9 @@
 ---
 jobs:
 - name: sawmill
-  instances: 3
+  instances: 1
   .: (( inject meta.jobs.sawmill ))
+  networks:
+  - name: sawmill
+    static_ips: (( static_ips 0, 1, 2, 3, 5 ))
+  resource_pool: small

--- a/.templates/bosh-lite/networks.yml
+++ b/.templates/bosh-lite/networks.yml
@@ -7,9 +7,3 @@ networks:
     gateway: 10.244.8.1
     static:
     - 10.244.8.2 - 10.244.8.60
-
-jobs:
-- name: sawmill
-  networks:
-  - name: sawmill
-    static_ips: (( static_ips 0, 1, 2, 3, 5 ))

--- a/.templates/bosh-lite/releases
+++ b/.templates/bosh-lite/releases
@@ -1,1 +1,2 @@
 sawmill
+toolbelt

--- a/.templates/bosh-lite/resource-pools.yml
+++ b/.templates/bosh-lite/resource-pools.yml
@@ -3,16 +3,10 @@ resource_pools:
   - name: small
     network: sawmill
     stemcell: (( grab meta.stemcell ))
-
     cloud_properties: {}
 
 compilation:
   network: sawmill
   workers: 1
   reuse_compilation_vms: true
-
   cloud_properties: {}
-
-jobs:
-  - name: sawmill
-    resource_pool: small

--- a/.templates/bosh-lite/update.yml
+++ b/.templates/bosh-lite/update.yml
@@ -2,4 +2,3 @@
 update:
   canary_watch_time: 1000-60000
   update_watch_time: 1000-60000
-  max_in_flight: 1

--- a/.templates/vsphere/jobs.yml
+++ b/.templates/vsphere/jobs.yml
@@ -2,51 +2,25 @@
 jobs:
 - name: sawmill_z1
   instances: 1
-  persistent_disk: 4096
-
-  templates:
-    - { release: sawmill, name: sawmill }
-    - { release: toolbelt, name: toolbelt }
-    - { release: toolbelt, name: toolbelt-quick }
-
+  .: (( inject meta.jobs.sawmill ))
   networks:
-  - name: sawmill_z1 
-    static_ips: (( static_ips(0, 1) )) 
-
+  - name: sawmill_z1
+    static_ips: (( static_ips(0, 1) ))
   resource_pool: small_z1
 
-  properties:
-    sawmill: (( grab properties.sawmill ))
+- name: sawmill_z2
+  instances: 1
+  .: (( inject meta.jobs.sawmill ))
+  networks:
+  - name: sawmill_z2
+    static_ips: (( static_ips(0, 1) ))
+  resource_pool: small_z2
 
-  #- name: sawmill_z2
-  #  instances: 1
-  #  persistent_disk: 4096
-  #  templates:
-  #    - { release: sawmill, name: sawmill }
-  #    - { release: toolbelt, name: toolbelt }
-  #    - { release: toolbelt, name: toolbelt-quick }
-  #  .: (( inject meta.jobs.sawmill ))
-  #  networks:
-  #  - name: sawmill_z2
-  #    static_ips: (( static_ips(0, 1) )) 
-  #  resource_pool: small_z2
-  #  properties:
-  #    sawmill: (( grab properties.sawmill ))
-  #
-  #- name: sawmill_z3
-  #  instances: 1
-  #  persistent_disk: 4096
-  #  templates:
-  #    - { release: sawmill, name: sawmill }
-  #    - { release: toolbelt, name: toolbelt }
-  #    - { release: toolbelt, name: toolbelt-quick }
-  #  .: (( inject meta.jobs.sawmill ))
-  #  networks:
-  #  - name: sawmill_z3
-  #    static_ips: (( static_ips(0, 1) )) 
-  #  resource_pool: small_z3
-  #  properties:
-  #    sawmill: (( grab properties.sawmill ))
-  #
+- name: sawmill_z3
+  instances: 1
+  .: (( inject meta.jobs.sawmill ))
 
-
+  networks:
+  - name: sawmill_z3
+    static_ips: (( static_ips(0, 1) ))
+  resource_pool: small_z3

--- a/.templates/vsphere/networks.yml
+++ b/.templates/vsphere/networks.yml
@@ -9,8 +9,7 @@ networks:
     static: (( param "Enter the static IP ranges for this subnet (networks.0<sawmill_z1>.subnets.static)" ))
     reserved: (( param "Enter the reserved IP ranges for this subnet (networks.0<sawmill_z1>.subnets.reserved)" ))
     cloud_properties:
-      security_groups: (( grab meta.security_groups ))
-      subnet: (( param "Enter the AWS subnet ID for this subnet (networks.0<sawmill_z1>.subnets.cloud_properties.subnet))" ))
+      name: (( param "What is the name of the vSphere network for this subnet?" ))
 
 - name: sawmill_z2
   type: manual
@@ -21,8 +20,7 @@ networks:
     static: (( param "Enter the static IP ranges for this subnet (networks.0<sawmill_z1>.subnets.static)" ))
     reserved: (( param "Enter the reserved IP ranges for this subnet (networks.0<sawmill_z1>.subnets.reserved)" ))
     cloud_properties:
-      security_groups: (( grab meta.security_groups ))
-      subnet: (( param "Enter the AWS subnet ID for this subnet (networks.0<sawmill_z1>.subnets.cloud_properties.subnet))" ))
+      name: (( param "What is the name of the vSphere network for this subnet?" ))
 
 - name: sawmill_z3
   type: manual
@@ -33,8 +31,4 @@ networks:
     static: (( param "Enter the static IP ranges for this subnet (networks.0<sawmill_z1>.subnets.static)" ))
     reserved: (( param "Enter the reserved IP ranges for this subnet (networks.0<sawmill_z1>.subnets.reserved)" ))
     cloud_properties:
-      security_groups: (( grab meta.security_groups ))
-      subnet: (( param "Enter the AWS subnet ID for this subnet (networks.0<sawmill_z1>.subnets.cloud_properties.subnet))" ))
-
-
-
+      name: (( param "What is the name of the vSphere network for this subnet?" ))

--- a/.templates/vsphere/releases
+++ b/.templates/vsphere/releases
@@ -1,1 +1,2 @@
 sawmill
+toolbelt

--- a/.templates/vsphere/update.yml
+++ b/.templates/vsphere/update.yml
@@ -2,4 +2,3 @@
 update:
   canary_watch_time: 1000-60000
   update_watch_time: 1000-60000
-  max_in_flight: 1

--- a/global/properties.yml
+++ b/global/properties.yml
@@ -1,9 +1,5 @@
 ---
 properties:
-
   sawmill:
-
     skip_ssl_verify: (( param "Specify whether or not to skip SSL verification (properties.sawmill.skip_ssl_verify)" ))
-
     users: (( param "Specify admin user name & password (properties.sawmill.users.0.{name,pass})" ))
-


### PR DESCRIPTION
Removed some redundant properties that were globally defined
Toolbelt was used in the templates, but not allowed in site-level releases by default. It is now.
Made bosh-lite network/resource pools be applied to jobs in the same locations that the aws/vsphere counterparts are for consistency.
Updated the vSphere jobs to have all 3 zones, updated the network cloud properties for vSphere
