### PR TITLE
adding user and password properties

### DIFF
--- a/.templates/aws/properties.yml
+++ b/.templates/aws/properties.yml
@@ -1,3 +1,9 @@
 ---
 meta:
   sawmill_servers: (( grab jobs.sawmill_z1.networks.sawmill_z1.static_ips jobs.sawmill_z2.networks.sawmill_z2.static_ips jobs.sawmill_z3.networks.sawmill_z3.static_ips ))
+
+properties:
+  sawmill:
+    users:
+      - name: admin
+        pass: (( vault meta.vault_prefix "/users/admin:password" ))

--- a/.templates/bosh-lite/properties.yml
+++ b/.templates/bosh-lite/properties.yml
@@ -5,3 +5,6 @@ meta:
 properties:
   sawmill:
     skip_ssl_verify: true
+    users:
+      - name: admin
+        pass: (( vault meta.vault_prefix "/users/admin:password" ))

--- a/.templates/vsphere/properties.yml
+++ b/.templates/vsphere/properties.yml
@@ -1,3 +1,9 @@
 ---
 meta:
   sawmill_servers: (( grab jobs.sawmill_z1.networks.sawmill_z1.static_ips jobs.sawmill_z2.networks.sawmill_z2.static_ips jobs.sawmill_z3.networks.sawmill_z3.static_ips ))
+
+properties:
+  sawmill:
+    users:
+      - name: admin
+        pass: (( vault meta.vault_prefix "/users/admin:password" ))


### PR DESCRIPTION
After adding this, you do not need to configure anything to deploy sawmill in bosh-lite after you run the `genesis new site` and `genesis new env` commands.